### PR TITLE
enable rendering in related field access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,22 @@
 language: python
 
 python:
+  - "3.5"
   - "3.4"
   - "3.3"
   - "2.7"
+  - "pypy"
 
 before_install:
   - pip install codecov
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements/test.txt
+install:
+  - pip install -r requirements/test.txt
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.3" ]]; then pip install -U "django<1.9"; fi
 
 # command to run tests using coverage, e.g. python setup.py test
-script: coverage run --source templatefield runtests.py
+script: coverage run --branch --source templatefield runtests.py
 
 after_success:
   - codecov

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 * Percy Perez <percyp3@gmail.com>
+* Brad Pitcher <bradpitcher@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Then use it in a project::
     class TemplatedText(models.Model):
         value = fields.TemplateTextField()
 
-        # Manger that returns rendered templates. This will be the default
+        # Manager that returns rendered templates. This will be the default
         # manager since it is first. Now, when accessed via `Related Models`_
         # this field will also be rendered.
         objects_rendered = managers.RenderTemplateManager()

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,9 @@ Then use it in a project::
     class TemplatedText(models.Model):
         value = fields.TemplateTextField()
 
-        # Manger that returns rendered templates.
+        # Manger that returns rendered templates. This will be the default
+        # manager since it is first. Now, when accessed via `Related Models`_
+        # this field will also be rendered.
         objects_rendered = managers.RenderTemplateManager()
         # Django's default manager returns unrendered templates.
         objects_unrendered = models.Manager()
@@ -46,6 +48,30 @@ Context can also be added to querysets like so:
     TemplatedText.objects_rendered.with_context({'template_var2': value2})
 
 
+Related Models
+--------------
+
+If a ``TemplateTextField`` will be accessed from another model through a
+``ForeignKey`` relationship, Django will use the default manager to render the
+``TemplateTextField``. For example, if we define this additional model:
+
+    class RelatedToTemplatedText(models.Model):
+        templated_text = models.ForeignKey(TemplatedText)
+
+We can expect to see fields accessed via ``templated_text`` rendered properly.
+
+Admin
+-----
+
+Using ``RenderTemplateManager`` as the default has the unfortunate side effect
+of rendering your fields in the Django admin, so we have provided a class from
+which you can inherit to solve that problem. Ex:
+
+    from templatefield import admin
+
+    class TemplatedTextAdmin(admin.UnrenderedAdmin):
+        ...
+
 Running Tests
 --------------
 
@@ -53,4 +79,3 @@ Running Tests
     source <YOURVIRTUALENV>/bin/activate
     (myenv) $ pip install -r requirements/test.txt
     (myenv) $ python runtests.py
-

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if sys.argv[-1] == 'tag':
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
+python_version = (sys.version_info.major, sys.version_info.minor)
 setup(
     name='django-template-field',
     version=version,
@@ -44,8 +45,7 @@ setup(
         'templatefield',
     ],
     include_package_data=True,
-    install_requires=[
-    ],
+    install_requires=['django<1.9'] if python_version == (3, 3) else [],
     license="BSD",
     zip_safe=False,
     keywords='django-template-field',
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',        
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: PyPy'
     ],
 )

--- a/templatefield/admin.py
+++ b/templatefield/admin.py
@@ -1,0 +1,12 @@
+from django.contrib import admin
+
+
+class UnrenderedAdmin(admin.ModelAdmin):
+    """ Make sure template fields aren't rendered in the Django admin. """
+
+    def get_queryset(self, request):
+        """ Remove ``show_rendered`` from the context, if it's there. """
+        qs = super(UnrenderedAdmin, self).get_queryset(request)
+        if 'show_rendered' in qs.query.context:
+            del qs.query.context['show_rendered']
+        return qs

--- a/templatefield/managers.py
+++ b/templatefield/managers.py
@@ -2,6 +2,7 @@ from django.db import models
 
 
 class RenderTemplateManager(models.Manager):
+    use_for_related_fields = True
 
     def get_queryset(self):
         qs = super(RenderTemplateManager, self).get_queryset()

--- a/templatefield/test/models.py
+++ b/templatefield/test/models.py
@@ -4,7 +4,11 @@ from templatefield import fields, managers
 
 
 class TemplatedText(models.Model):
-    value = fields.TemplateTextField()
+    value = fields.TemplateTextField(null=True)
 
     objects_rendered = managers.RenderTemplateManager()
     objects_unrendered = models.Manager()
+
+
+class RelatedToTemplatedText(models.Model):
+    templated_text = models.ForeignKey(TemplatedText)

--- a/templatefield/test/test_admin.py
+++ b/templatefield/test/test_admin.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_admin
+------------
+
+Tests for `django-template-field` admin classes.
+"""
+import pytest
+
+from django.contrib.admin.sites import AdminSite
+from mock import MagicMock
+
+from .models import RelatedToTemplatedText, TemplatedText
+from ..admin import UnrenderedAdmin
+
+
+class TestUnrenderedAdmin(object):
+    def test_get_queryset(self):
+        # Check the resulting context in both models
+        for model in [RelatedToTemplatedText, TemplatedText]:
+            admin = UnrenderedAdmin(model, AdminSite())
+            qs = admin.get_queryset(MagicMock())
+            assert qs.query.context == {}

--- a/templatefield/test/test_fields.py
+++ b/templatefield/test/test_fields.py
@@ -10,7 +10,7 @@ Tests for `django-template-field` fields.
 import pytest
 from django.test.utils import override_settings
 
-from .models import TemplatedText
+from .models import RelatedToTemplatedText, TemplatedText
 
 
 pytestmark = pytest.mark.django_db
@@ -22,6 +22,13 @@ class TestTemplatefield(object):
         self.tmpl = "{{ template_var }} are pretty neat"
         self.model = TemplatedText(value=self.tmpl)
         self.model.save()
+        self.related_model = RelatedToTemplatedText(templated_text=self.model)
+        self.related_model.save()
+
+    def test_none(self):
+        tt = TemplatedText(value=None)
+        tt.save()
+        assert TemplatedText.objects_unrendered.first().value == None
 
     def test_unrendered(self):
         self.setUp()
@@ -32,6 +39,11 @@ class TestTemplatefield(object):
         self.setUp()
         tt = TemplatedText.objects_rendered.first()
         assert tt.value == "Dogs are pretty neat"
+
+    def test_rendered_related(self):
+        self.setUp()
+        rttt = RelatedToTemplatedText.objects.first()
+        assert rttt.templated_text.value == "Dogs are pretty neat"
 
     def test_qs_context(self):
         self.setUp()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34
+envlist = pypy, py27, py33, py34, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This is to enable rendering for related model fields. I made a few more changes while I was at it:
- Restricted Django when using Python 3.3 to < 1.9, which no longer supports it
- Added Python 3.5 and pypy to the tox and travis matrices
- Added the `--branch` flag to the coverage command
- Added my name to `AUTHORS` :smile: 
- Added one more fields test to bring us to 100% coverage! \o/
