### PR TITLE
add setting to globally enable/disable rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,10 @@ Context can also be added to querysets like so:
 
     TemplatedText.objects_rendered.with_context({'template_var2': value2})
 
+Add the following to `settings` to disable rendering globally:
+
+    TEMPLATE_FIELD_RENDER = False
+
 
 Related Models
 --------------

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Then use it in a project::
         # Django's default manager returns unrendered templates.
         objects_unrendered = models.Manager()
 
-Extra context can be added in `settings` like so:
+Extra context can be added in ``settings`` like so:
 
     TEMPLATE_FIELD_CONTEXT = { 'template_var': value }
 
@@ -47,9 +47,15 @@ Context can also be added to querysets like so:
 
     TemplatedText.objects_rendered.with_context({'template_var2': value2})
 
-Add the following to `settings` to disable rendering globally:
+If you dump fixtures with ``RenderTemplateManager`` as the default manager,
+django will render the exported data. To work around that, create an alternate
+settings file for your project with the following setting:
 
     TEMPLATE_FIELD_RENDER = False
+
+Then you can dump your unrendered data like so:
+
+    ./manage.py dumpdata myapp.mymodel --settings=myapp.dump_settings
 
 
 Related Models

--- a/templatefield/fields.py
+++ b/templatefield/fields.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.template import Context, Template
-from . import settings
+from .settings import get_setting
 
 
 class TemplateTextField(models.TextField):
@@ -9,13 +9,14 @@ class TemplateTextField(models.TextField):
         if value is None:
             return None
 
-        if not context.get('show_rendered'):
+        should_render = get_setting('TEMPLATE_FIELD_RENDER')
+        if not context.get('show_rendered') or not should_render:
             # `show_rendered` flag is unset, return the templeate
             return value
 
         # Return the rendered template
         template = Template(value)
         context_dict = {}
-        context_dict.update(settings.TEMPLATE_FIELD_CONTEXT)
+        context_dict.update(get_setting('TEMPLATE_FIELD_CONTEXT'))
         context_dict.update(context.get('tmpl_context', {}))
         return template.render(Context(context_dict))

--- a/templatefield/settings.py
+++ b/templatefield/settings.py
@@ -1,4 +1,17 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 
-TEMPLATE_FIELD_CONTEXT = getattr(settings, 'TEMPLATE_FIELD_CONTEXT', {})
+def get_setting(setting):
+    """ Get the specified django setting, or it's default value """
+    defaults = {
+        # The context to use for rendering fields
+        'TEMPLATE_FIELD_CONTEXT': {},
+        # When this is False, don't do any TemplateField rendering
+        'TEMPLATE_FIELD_RENDER': True
+    }
+    try:
+        return getattr(settings, setting, defaults[setting])
+    except KeyError:
+        msg = "{0} is not specified in your settings".format(setting)
+        raise ImproperlyConfigured(msg)

--- a/templatefield/test/test_settings.py
+++ b/templatefield/test/test_settings.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_settings
+-------------
+
+Tests for `django-template-field` settings
+"""
+import json
+import pytest
+import sys
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management import call_command
+from django.test.utils import override_settings
+
+from ..settings import get_setting
+from .models import TemplatedText
+
+
+pytestmark = pytest.mark.django_db
+
+
+class TestSettings(object):
+    def setUp(self):
+        self.tmpl = "{{ template_var }} are pretty neat"
+        self.model = TemplatedText(value=self.tmpl)
+        self.model.save()
+
+    @override_settings(TEMPLATE_FIELD_CONTEXT={'test_var': 'val'})
+    def test_get_setting(self):
+        assert get_setting('TEMPLATE_FIELD_CONTEXT') == {'test_var': 'val'}
+        assert get_setting('TEMPLATE_FIELD_RENDER') == True
+        pytest.raises(ImproperlyConfigured, get_setting, 'FAKE_SETTING')
+
+    def test_render_true(self, capsys):
+        self.setUp()
+        call_command('dumpdata', 'test.templatedtext')
+        out, _ = capsys.readouterr()
+        fixture = json.loads(out)
+
+        assert len(fixture) == 1
+        assert fixture[0]['fields']['value'] == 'Dogs are pretty neat'
+
+    def test_render_false(self, capsys):
+        with override_settings(TEMPLATE_FIELD_RENDER=False):
+            self.setUp()
+            call_command('dumpdata', 'test.templatedtext')
+            out, _ = capsys.readouterr()
+            fixture = json.loads(out)
+            fixture_value = fixture[0]['fields']['value']
+
+            assert len(fixture) == 1
+            assert fixture_value == '{{ template_var }} are pretty neat'


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. Added a setting `TEMPLATE_FIELD_RENDER` to make it easy to disable rendering for things like `./manage.py dumpdata`. I also changed it so that app settings are retrieved via a `get_settings` method. Otherwise, the `override_settings` decorator didn't work for testing.
